### PR TITLE
Close all MongoClients created in tests

### DIFF
--- a/tests/test_getmore_sharded.py
+++ b/tests/test_getmore_sharded.py
@@ -40,7 +40,7 @@ class TestGetmoreSharded(unittest.TestCase):
         client = MongoClient('mongodb://%s:%d,%s:%d' % (
             servers[0].host, servers[0].port,
             servers[1].host, servers[1].port))
-
+        self.addCleanup(client.close)
         collection = client.db.collection
         cursor = collection.find()
         with going(next, cursor):

--- a/tests/test_list_indexes.py
+++ b/tests/test_list_indexes.py
@@ -33,6 +33,7 @@ class TestListIndexes(unittest.TestCase):
         server.run()
         self.addCleanup(server.stop)
         client = MongoClient(server.uri)
+        self.addCleanup(client.close)
         with going(client.test.collection.list_indexes) as cursor:
             request = server.receives(
                 OpQuery, namespace='test.system.indexes')
@@ -52,6 +53,7 @@ class TestListIndexes(unittest.TestCase):
         server.run()
         self.addCleanup(server.stop)
         client = MongoClient(server.uri)
+        self.addCleanup(client.close)
         with going(client.test.collection.list_indexes) as cursor:
             request = server.receives(
                 listIndexes='collection', namespace='test')

--- a/tests/test_max_staleness.py
+++ b/tests/test_max_staleness.py
@@ -29,7 +29,9 @@ class TestMaxStalenessMongos(unittest.TestCase):
         # No maxStalenessSeconds.
         uri = 'mongodb://localhost:%d/?readPreference=secondary' % mongos.port
 
-        with going(MongoClient(uri).db.coll.find_one) as future:
+        client = MongoClient(uri)
+        self.addCleanup(client.close)
+        with going(client.db.coll.find_one) as future:
             request = mongos.receives()
             self.assertNotIn(
                 'maxStalenessSeconds',
@@ -47,7 +49,9 @@ class TestMaxStalenessMongos(unittest.TestCase):
         uri = 'mongodb://localhost:%d/?readPreference=secondary' \
               '&maxStalenessSeconds=1' % mongos.port
 
-        with going(MongoClient(uri).db.coll.find_one) as future:
+        client = MongoClient(uri)
+        self.addCleanup(client.close)
+        with going(client.db.coll.find_one) as future:
             request = mongos.receives()
             self.assertEqual(
                 1,

--- a/tests/test_mixed_version_sharded.py
+++ b/tests/test_mixed_version_sharded.py
@@ -53,6 +53,10 @@ class TestMixedVersionSharded(unittest.TestCase):
 
         self.client = MongoClient(self.mongoses_uri)
 
+    def tearDown(self):
+        if hasattr(self, 'client') and self.client:
+            self.client.close()
+
 
 def create_mixed_version_sharded_test(upgrade):
     def test(self):

--- a/tests/test_mongos_command_read_mode.py
+++ b/tests/test_mongos_command_read_mode.py
@@ -32,7 +32,9 @@ class TestMongosCommandReadMode(unittest.TestCase):
         self.addCleanup(server.stop)
         server.run()
 
-        collection = MongoClient(server.uri).test.collection
+        client = MongoClient(server.uri)
+        self.addCleanup(client.close)
+        collection = client.test.collection
         with going(collection.aggregate, []):
             command = server.receives(aggregate='collection', pipeline=[])
             self.assertFalse(command.slave_ok, 'SlaveOkay set')
@@ -63,6 +65,7 @@ def create_mongos_read_mode_test(mode, operation):
                                     tag_sets=None)
 
         client = MongoClient(server.uri, read_preference=pref)
+        self.addCleanup(client.close)
         with going(operation.function, client) as future:
             request = server.receive()
             request.reply(operation.reply)

--- a/tests/test_query_read_pref_sharded.py
+++ b/tests/test_query_read_pref_sharded.py
@@ -33,6 +33,7 @@ class TestQueryAndReadModeSharded(unittest.TestCase):
         self.addCleanup(server.stop)
 
         client = MongoClient(server.uri)
+        self.addCleanup(client.close)
 
         modes_without_query = (
             Primary(),

--- a/tests/test_reset_and_request_check.py
+++ b/tests/test_reset_and_request_check.py
@@ -43,8 +43,11 @@ class TestResetAndRequestCheck(unittest.TestCase):
         self.addCleanup(self.server.stop)
 
         self.client = MongoClient(self.server.uri, socketTimeoutMS=100)
-        self.addCleanup(self.client.close)
         wait_until(lambda: self.client.nodes, 'connect to standalone')
+
+    def tearDown(self):
+        if hasattr(self, 'client') and self.client:
+            self.client.close()
 
     def _test_disconnect(self, operation):
         # Application operation fails. Test that client resets server
@@ -118,13 +121,13 @@ def create_reset_test(operation, test_method):
 
 def generate_reset_tests():
     test_methods = [
-        (TestResetAndRequestCheck._test_disconnect, 'test_disconnect'), 
+        (TestResetAndRequestCheck._test_disconnect, 'test_disconnect'),
         (TestResetAndRequestCheck._test_timeout, 'test_timeout'),
         (TestResetAndRequestCheck._test_not_master, 'test_not_master'),
     ]
-    
+
     matrix = itertools.product(operations, test_methods)
-    
+
     for entry in matrix:
         operation, (test_method, name) = entry
         test = create_reset_test(operation, test_method)

--- a/tests/test_slave_okay_rs.py
+++ b/tests/test_slave_okay_rs.py
@@ -49,6 +49,7 @@ def create_slave_ok_rs_test(operation):
         assert not operation.op_type == 'always-use-secondary'
 
         client = MongoClient(self.primary.uri, replicaSet='rs')
+        self.addCleanup(client.close)
         with going(operation.function, client):
             request = self.primary.receive()
             request.reply(operation.reply)

--- a/tests/test_slave_okay_sharded.py
+++ b/tests/test_slave_okay_sharded.py
@@ -68,6 +68,7 @@ def create_slave_ok_sharded_test(mode, operation):
                                     tag_sets=None)
 
         client = MongoClient(self.mongoses_uri, read_preference=pref)
+        self.addCleanup(client.close)
         with going(operation.function, client):
             request = self.q.get(timeout=1)
             request.reply(operation.reply)

--- a/tests/test_slave_okay_single.py
+++ b/tests/test_slave_okay_single.py
@@ -61,6 +61,7 @@ def create_slave_ok_single_test(mode, server_type, ismaster, operation):
                                     tag_sets=None)
 
         client = MongoClient(self.server.uri, read_preference=pref)
+        self.addCleanup(client.close)
         with going(operation.function, client):
             request = self.server.receive()
             request.reply(operation.reply)


### PR DESCRIPTION
This was an attempt to fix the PeriodicExecutor tracebacks after running the tests. Unfortunately, this doesn't fix the problem which seems to be in `tests/test_reset_and_request_check.py`.

Even with these changes:
```
$ python setup.py test -s tests.test_reset_and_request_check
running test
Searching for pymongo
Best match: pymongo 3.4.0
Processing pymongo-3.4.0-py2.7-macosx-10.11-intel.egg

Using /Users/shane/git/pymongo-mockup-tests/.eggs/pymongo-3.4.0-py2.7-macosx-10.11-intel.egg
Searching for mockupdb
Best match: mockupdb 1.2.0.dev0
Processing mockupdb-1.2.0.dev0-py2.7.egg

Using /Users/shane/git/pymongo-mockup-tests/.eggs/mockupdb-1.2.0.dev0-py2.7.egg
running egg_info
writing PyMongo_MockupDB_tests.egg-info/PKG-INFO
writing top-level names to PyMongo_MockupDB_tests.egg-info/top_level.txt
writing dependency_links to PyMongo_MockupDB_tests.egg-info/dependency_links.txt
reading manifest file 'PyMongo_MockupDB_tests.egg-info/SOURCES.txt'
writing manifest file 'PyMongo_MockupDB_tests.egg-info/SOURCES.txt'
running build_ext
test_disconnect_aggregate (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_disconnect_collection_names (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_disconnect_command (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_disconnect_count (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_disconnect_find_one (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_disconnect_inline_mapreduce (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_disconnect_listCollections (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_disconnect_listIndexes (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_disconnect_mapreduce (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_disconnect_options_new (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_disconnect_options_old (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_disconnect_secondary_command (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_disconnect_system_indexes (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_not_master_aggregate (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_not_master_collection_names (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_not_master_command (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_not_master_count (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_not_master_find_one (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_not_master_inline_mapreduce (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_not_master_listCollections (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_not_master_listIndexes (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_not_master_mapreduce (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_not_master_options_new (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_not_master_options_old (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_not_master_secondary_command (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_not_master_system_indexes (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_timeout_aggregate (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_timeout_collection_names (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_timeout_command (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_timeout_count (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_timeout_find_one (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_timeout_inline_mapreduce (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_timeout_listCollections (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_timeout_listIndexes (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_timeout_mapreduce (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_timeout_options_new (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_timeout_options_old (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_timeout_secondary_command (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok
test_timeout_system_indexes (tests.test_reset_and_request_check.TestResetAndRequestCheck) ... ok

----------------------------------------------------------------------
Ran 39 tests in 36.466s

OK
Exception in thread pymongo_kill_cursors_thread:
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "build/bdist.macosx-10.11-intel/egg/pymongo/periodic_executor.py", line 124, in _run
TypeError: 'NoneType' object is not callable

Exception in thread pymongo_kill_cursors_thread:
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "build/bdist.macosx-10.11-intel/egg/pymongo/periodic_executor.py", line 124, in _run
TypeError: 'NoneType' object is not callable
```