### PR TITLE
PYTHON-1377 Update tests for OP_MSG

### DIFF
--- a/tests/test_handshake.py
+++ b/tests/test_handshake.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from mockupdb import MockupDB, OpReply, absent, Command, go
+from mockupdb import MockupDB, OpReply, OpMsg, absent, Command, go
 from pymongo import MongoClient, version as pymongo_version, version_tuple
 
 from tests import unittest
@@ -99,7 +99,10 @@ class TestHandshake(unittest.TestCase):
                     request.ok(primary_response)
             else:
                 # Command succeeds.
-                request.assert_matches(Command('whatever'))
+                if version_tuple >= (3, 7):
+                    request.assert_matches(OpMsg('whatever'))
+                else:
+                    request.assert_matches(Command('whatever'))
                 request.ok()
                 assert future()
                 return

--- a/tests/test_mongos_command_read_mode.py
+++ b/tests/test_mongos_command_read_mode.py
@@ -29,7 +29,7 @@ class TestMongosCommandReadMode(unittest.TestCase):
     def test_aggregate(self):
         server = MockupDB()
         server.autoresponds('ismaster', ismaster=True, msg='isdbgrid',
-                            minWireVersion=2, maxWireVersion=6)
+                            minWireVersion=2, maxWireVersion=5)
         self.addCleanup(server.stop)
         server.run()
 
@@ -61,7 +61,7 @@ def create_mongos_read_mode_test(mode, operation):
         self.addCleanup(server.stop)
         server.run()
         server.autoresponds('ismaster', ismaster=True, msg='isdbgrid',
-                            minWireVersion=2, maxWireVersion=6)
+                            minWireVersion=2, maxWireVersion=5)
 
         pref = make_read_preference(read_pref_mode_from_name(mode),
                                     tag_sets=None)

--- a/tests/test_op_msg_read_preference.py
+++ b/tests/test_op_msg_read_preference.py
@@ -16,7 +16,7 @@ import copy
 import itertools
 
 from mockupdb import MockupDB, going, CommandBase
-from pymongo import MongoClient, ReadPreference
+from pymongo import MongoClient, ReadPreference, version_tuple
 from pymongo.read_preferences import (make_read_preference,
                                       read_pref_mode_from_name,
                                       _MONGOS_MODES)
@@ -27,6 +27,12 @@ from tests.operations import operations
 
 class OpMsgReadPrefBase(unittest.TestCase):
     single_mongod = False
+
+    @classmethod
+    def setUpClass(cls):
+        super(OpMsgReadPrefBase, cls).setUpClass()
+        if version_tuple < (3, 7):
+            raise unittest.SkipTest("requires PyMongo 3.7")
 
     @classmethod
     def add_test(cls, mode, test_name, test):

--- a/tests/test_op_msg_read_preference.py
+++ b/tests/test_op_msg_read_preference.py
@@ -164,7 +164,6 @@ def create_op_msg_read_mode_test(mode, operation):
 
         future()  # No error.
 
-
         self.assertEqual(expected_pref.document,
                          request.doc.get('$readPreference'))
         self.assertNotIn('$query', request.doc)

--- a/tests/test_op_msg_read_preference.py
+++ b/tests/test_op_msg_read_preference.py
@@ -1,0 +1,173 @@
+# Copyright 2018-present MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import itertools
+
+from mockupdb import MockupDB, going, CommandBase
+from pymongo import MongoClient, ReadPreference
+from pymongo.read_preferences import (make_read_preference,
+                                      read_pref_mode_from_name,
+                                      _MONGOS_MODES)
+
+from tests import unittest
+from tests.operations import operations
+
+
+class OpMsgReadPrefBase(unittest.TestCase):
+
+    def setup_client(self, read_preference=None):
+        raise NotImplementedError
+
+
+class TestOpMsgMongos(OpMsgReadPrefBase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestOpMsgMongos, cls).setUpClass()
+        auto_ismaster = {
+            'ismaster': True,
+            'msg': 'isdbgrid',  # Mongos.
+            'minWireVersion': 2,
+            'maxWireVersion': 6,
+        }
+        cls.primary = MockupDB(auto_ismaster=auto_ismaster)
+        cls.primary.run()
+        cls.secondary = cls.primary
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.primary.stop()
+        super(TestOpMsgMongos, cls).tearDownClass()
+
+    @classmethod
+    def add_test(cls, mode, test_name, test):
+        setattr(cls, test_name, test)
+
+    def setup_client(self, read_preference=None):
+        if read_preference is None:
+            client = MongoClient(self.primary.uri)
+        else:
+            client = MongoClient(self.primary.uri,
+                                 read_preference=read_preference)
+        self.addCleanup(client.close)
+        return client
+
+
+class TestOpMsgReplicaSet(OpMsgReadPrefBase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestOpMsgReplicaSet, cls).setUpClass()
+        cls.primary, cls.secondary = MockupDB(), MockupDB()
+        for server in cls.primary, cls.secondary:
+            server.run()
+
+        hosts = [server.address_string
+                 for server in (cls.primary, cls.secondary)]
+
+        primary_ismaster = {
+            'ismaster': True,
+            'setName': 'rs',
+            'hosts': hosts,
+            'minWireVersion': 2,
+            'maxWireVersion': 6,
+        }
+        cls.primary.autoresponds(CommandBase('ismaster'), primary_ismaster)
+        secondary_ismaster = copy.copy(primary_ismaster)
+        secondary_ismaster['ismaster'] = False
+        secondary_ismaster['secondary'] = True
+        cls.secondary.autoresponds(CommandBase('ismaster'), secondary_ismaster)
+
+    @classmethod
+    def tearDownClass(cls):
+        for server in cls.primary, cls.secondary:
+            server.stop()
+        super(TestOpMsgReplicaSet, cls).tearDownClass()
+
+    @classmethod
+    def add_test(cls, mode, test_name, test):
+        # Skip nearest tests since we don't know if we will select the primary
+        # or secondary.
+        if mode != 'nearest':
+            setattr(cls, test_name, test)
+
+    def setup_client(self, read_preference=None):
+        if read_preference is None:
+            client = MongoClient(self.primary.uri, replicaSet='rs')
+        else:
+            client = MongoClient(self.primary.uri,
+                                 replicaSet='rs',
+                                 read_preference=read_preference)
+
+        # Run a command on a secondary to discover the topology. This ensures
+        # that secondaryPreferred commands will select the secondary.
+        client.admin.command('ismaster',
+                             read_preference=ReadPreference.SECONDARY)
+        self.addCleanup(client.close)
+        return client
+
+
+def create_op_msg_read_mode_test(mode, operation):
+    def test(self):
+        pref = make_read_preference(read_pref_mode_from_name(mode),
+                                    tag_sets=None)
+
+        client = self.setup_client(read_preference=pref)
+
+        if operation.op_type == 'always-use-secondary':
+            expected_server = self.secondary
+            expected_pref = ReadPreference.SECONDARY.document
+        elif operation.op_type == 'must-use-primary':
+            expected_server = self.primary
+            expected_pref = ReadPreference.PRIMARY.document
+        elif operation.op_type == 'may-use-secondary':
+            if mode in ('primary', 'primaryPreferred'):
+                expected_server = self.primary
+            else:
+                expected_server = self.secondary
+            expected_pref = pref.document
+        else:
+            self.fail('unrecognized op_type %r' % operation.op_type)
+
+        with going(operation.function, client) as future:
+            request = expected_server.receive()
+            request.reply(operation.reply)
+
+        future()  # No error.
+
+        self.assertEqual(expected_pref, request.doc.get('$readPreference'))
+        self.assertNotIn('$query', request.doc)
+
+    return test
+
+
+def generate_op_msg_read_mode_tests():
+    matrix = itertools.product(_MONGOS_MODES, operations)
+
+    for entry in matrix:
+        mode, operation = entry
+        test = create_op_msg_read_mode_test(mode, operation)
+        test_name = 'test_%s_with_mode_%s' % (
+            operation.name.replace(' ', '_'), mode)
+        test.__name__ = test_name
+        TestOpMsgReplicaSet.add_test(mode, test_name, test)
+        TestOpMsgMongos.add_test(mode, test_name, test)
+
+
+generate_op_msg_read_mode_tests()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_query_read_pref_sharded.py
+++ b/tests/test_query_read_pref_sharded.py
@@ -15,7 +15,7 @@
 """Test PyMongo query and read preference with a sharded cluster."""
 
 from bson import SON
-from pymongo import MongoClient
+from pymongo import MongoClient, version_tuple
 from pymongo.read_preferences import (Primary,
                                       PrimaryPreferred,
                                       Secondary,
@@ -67,6 +67,7 @@ class TestQueryAndReadModeSharded(unittest.TestCase):
 
                     request.replies({'cursor': {'id': 0, 'firstBatch': [{}]}})
 
+    @unittest.skipUnless(version_tuple >= (3, 7), "requires PyMongo 3.7")
     def test_query_and_read_mode_sharded_op_msg(self):
         """Test OP_MSG sends non-primary $readPreference and never $query."""
         server = MockupDB()


### PR DESCRIPTION
This depends on the PyMongo changes in [PYTHON-1329](https://jira.mongodb.org/browse/PYTHON-1329) and the mongo-mockup-db changes in https://github.com/ajdavis/mongo-mockup-db/pull/15.