### PR TITLE
PYTHON-1674 Disable retryReads in network error tests

### DIFF
--- a/tests/test_reset_and_request_check.py
+++ b/tests/test_reset_and_request_check.py
@@ -18,7 +18,7 @@ import itertools
 from mockupdb import MockupDB, going, wait_until
 from pymongo.server_type import SERVER_TYPE
 from pymongo.errors import ConnectionFailure
-from pymongo import MongoClient
+from pymongo import MongoClient, version_tuple
 
 from tests import unittest
 from tests.operations import operations
@@ -42,7 +42,11 @@ class TestResetAndRequestCheck(unittest.TestCase):
         self.server.run()
         self.addCleanup(self.server.stop)
 
-        self.client = MongoClient(self.server.uri, socketTimeoutMS=100)
+        kwargs = {'socketTimeoutMS': 100}
+        # Disable retryable reads when pymongo supports it.
+        if version_tuple[:3] >= (3, 9):
+            kwargs['retryReads'] = False
+        self.client = MongoClient(self.server.uri, **kwargs)
         wait_until(lambda: self.client.nodes, 'connect to standalone')
 
     def tearDown(self):


### PR DESCRIPTION
Fixes the following test failures caused by automatic retries:
```
 [2019/03/01 16:19:59.681] ======================================================================
 [2019/03/01 16:19:59.681] FAIL: test_disconnect_aggregate (tests.test_reset_and_request_check.TestResetAndRequestCheck)
 [2019/03/01 16:19:59.681] ----------------------------------------------------------------------
 [2019/03/01 16:19:59.681] Traceback (most recent call last):
 [2019/03/01 16:19:59.681]   File "/data/mci/92728139bf6b9643f3bf981438af4a9f/pymongo-mockup-tests/tests/test_reset_and_request_check.py", line 117, in test
 [2019/03/01 16:19:59.681]     test_method(self, operation)
 [2019/03/01 16:19:59.681]   File "/data/mci/92728139bf6b9643f3bf981438af4a9f/pymongo-mockup-tests/tests/test_reset_and_request_check.py", line 65, in _test_disconnect
 [2019/03/01 16:19:59.681]     topology.select_server_by_address(self.server.address, 0)
 [2019/03/01 16:19:59.681] AssertionError: ConnectionFailure not raised
 [2019/03/01 16:19:59.681] ======================================================================
 [2019/03/01 16:19:59.681] FAIL: test_disconnect_count (tests.test_reset_and_request_check.TestResetAndRequestCheck)
 [2019/03/01 16:19:59.681] ----------------------------------------------------------------------
 [2019/03/01 16:19:59.681] Traceback (most recent call last):
 [2019/03/01 16:19:59.681]   File "/data/mci/92728139bf6b9643f3bf981438af4a9f/pymongo-mockup-tests/tests/test_reset_and_request_check.py", line 117, in test
 [2019/03/01 16:19:59.681]     test_method(self, operation)
 [2019/03/01 16:19:59.681]   File "/data/mci/92728139bf6b9643f3bf981438af4a9f/pymongo-mockup-tests/tests/test_reset_and_request_check.py", line 65, in _test_disconnect
 [2019/03/01 16:19:59.681]     topology.select_server_by_address(self.server.address, 0)
 [2019/03/01 16:19:59.681] AssertionError: ConnectionFailure not raised
 [2019/03/01 16:19:59.681] ======================================================================
 [2019/03/01 16:19:59.681] FAIL: test_disconnect_find_one (tests.test_reset_and_request_check.TestResetAndRequestCheck)
 [2019/03/01 16:19:59.681] ----------------------------------------------------------------------
 [2019/03/01 16:19:59.681] Traceback (most recent call last):
 [2019/03/01 16:19:59.681]   File "/data/mci/92728139bf6b9643f3bf981438af4a9f/pymongo-mockup-tests/tests/test_reset_and_request_check.py", line 117, in test
 [2019/03/01 16:19:59.681]     test_method(self, operation)
 [2019/03/01 16:19:59.681]   File "/data/mci/92728139bf6b9643f3bf981438af4a9f/pymongo-mockup-tests/tests/test_reset_and_request_check.py", line 65, in _test_disconnect
 [2019/03/01 16:19:59.681]     topology.select_server_by_address(self.server.address, 0)
 [2019/03/01 16:19:59.681] AssertionError: ConnectionFailure not raised
 [2019/03/01 16:19:59.681] ======================================================================
 [2019/03/01 16:19:59.681] FAIL: test_disconnect_listCollections (tests.test_reset_and_request_check.TestResetAndRequestCheck)
 [2019/03/01 16:19:59.681] ----------------------------------------------------------------------
 [2019/03/01 16:19:59.681] Traceback (most recent call last):
 [2019/03/01 16:19:59.681]   File "/data/mci/92728139bf6b9643f3bf981438af4a9f/pymongo-mockup-tests/tests/test_reset_and_request_check.py", line 117, in test
 [2019/03/01 16:19:59.681]     test_method(self, operation)
 [2019/03/01 16:19:59.681]   File "/data/mci/92728139bf6b9643f3bf981438af4a9f/pymongo-mockup-tests/tests/test_reset_and_request_check.py", line 65, in _test_disconnect
 [2019/03/01 16:19:59.681]     topology.select_server_by_address(self.server.address, 0)
 [2019/03/01 16:19:59.681] AssertionError: ConnectionFailure not raised
 [2019/03/01 16:19:59.681] ======================================================================
 [2019/03/01 16:19:59.681] FAIL: test_disconnect_listIndexes (tests.test_reset_and_request_check.TestResetAndRequestCheck)
 [2019/03/01 16:19:59.681] ----------------------------------------------------------------------
 [2019/03/01 16:19:59.681] Traceback (most recent call last):
 [2019/03/01 16:19:59.681]   File "/data/mci/92728139bf6b9643f3bf981438af4a9f/pymongo-mockup-tests/tests/test_reset_and_request_check.py", line 117, in test
 [2019/03/01 16:19:59.681]     test_method(self, operation)
 [2019/03/01 16:19:59.681]   File "/data/mci/92728139bf6b9643f3bf981438af4a9f/pymongo-mockup-tests/tests/test_reset_and_request_check.py", line 65, in _test_disconnect
 [2019/03/01 16:19:59.681]     topology.select_server_by_address(self.server.address, 0)
 [2019/03/01 16:19:59.681] AssertionError: ConnectionFailure not raised
 [2019/03/01 16:19:59.681] ======================================================================
 [2019/03/01 16:19:59.681] FAIL: test_disconnect_options (tests.test_reset_and_request_check.TestResetAndRequestCheck)
 [2019/03/01 16:19:59.681] ----------------------------------------------------------------------
 [2019/03/01 16:19:59.681] Traceback (most recent call last):
 [2019/03/01 16:19:59.681]   File "/data/mci/92728139bf6b9643f3bf981438af4a9f/pymongo-mockup-tests/tests/test_reset_and_request_check.py", line 117, in test
 [2019/03/01 16:19:59.681]     test_method(self, operation)
 [2019/03/01 16:19:59.681]   File "/data/mci/92728139bf6b9643f3bf981438af4a9f/pymongo-mockup-tests/tests/test_reset_and_request_check.py", line 65, in _test_disconnect
 [2019/03/01 16:19:59.681]     topology.select_server_by_address(self.server.address, 0)
 [2019/03/01 16:19:59.681] AssertionError: ConnectionFailure not raised
 [2019/03/01 16:19:59.681] ======================================================================
 [2019/03/01 16:19:59.681] FAIL: test_timeout_aggregate (tests.test_reset_and_request_check.TestResetAndRequestCheck)
 [2019/03/01 16:19:59.681] ----------------------------------------------------------------------
 [2019/03/01 16:19:59.681] Traceback (most recent call last):
 [2019/03/01 16:19:59.681]   File "/data/mci/92728139bf6b9643f3bf981438af4a9f/pymongo-mockup-tests/tests/test_reset_and_request_check.py", line 117, in test
 [2019/03/01 16:19:59.681]     test_method(self, operation)
 [2019/03/01 16:19:59.681]   File "/data/mci/92728139bf6b9643f3bf981438af4a9f/pymongo-mockup-tests/tests/test_reset_and_request_check.py", line 94, in _test_timeout
 [2019/03/01 16:19:59.681]     self.assertEqual(after, before, 'unneeded ismaster call')
 [2019/03/01 16:19:59.681] AssertionError: unneeded ismaster call
 [2019/03/01 16:19:59.681] ======================================================================
 [2019/03/01 16:19:59.681] FAIL: test_timeout_count (tests.test_reset_and_request_check.TestResetAndRequestCheck)
 [2019/03/01 16:19:59.681] ----------------------------------------------------------------------
 [2019/03/01 16:19:59.681] Traceback (most recent call last):
 [2019/03/01 16:19:59.681]   File "/data/mci/92728139bf6b9643f3bf981438af4a9f/pymongo-mockup-tests/tests/test_reset_and_request_check.py", line 117, in test
 [2019/03/01 16:19:59.681]     test_method(self, operation)
 [2019/03/01 16:19:59.681]   File "/data/mci/92728139bf6b9643f3bf981438af4a9f/pymongo-mockup-tests/tests/test_reset_and_request_check.py", line 94, in _test_timeout
 [2019/03/01 16:19:59.681]     self.assertEqual(after, before, 'unneeded ismaster call')
 [2019/03/01 16:19:59.681] AssertionError: unneeded ismaster call
 [2019/03/01 16:19:59.681] ======================================================================
 [2019/03/01 16:19:59.681] FAIL: test_timeout_find_one (tests.test_reset_and_request_check.TestResetAndRequestCheck)
 [2019/03/01 16:19:59.681] ----------------------------------------------------------------------
 [2019/03/01 16:19:59.681] Traceback (most recent call last):
 [2019/03/01 16:19:59.681]   File "/data/mci/92728139bf6b9643f3bf981438af4a9f/pymongo-mockup-tests/tests/test_reset_and_request_check.py", line 117, in test
 [2019/03/01 16:19:59.681]     test_method(self, operation)
 [2019/03/01 16:19:59.681]   File "/data/mci/92728139bf6b9643f3bf981438af4a9f/pymongo-mockup-tests/tests/test_reset_and_request_check.py", line 94, in _test_timeout
 [2019/03/01 16:19:59.681]     self.assertEqual(after, before, 'unneeded ismaster call')
 [2019/03/01 16:19:59.681] AssertionError: unneeded ismaster call
 [2019/03/01 16:19:59.681] ======================================================================
 [2019/03/01 16:19:59.681] FAIL: test_timeout_listCollections (tests.test_reset_and_request_check.TestResetAndRequestCheck)
 [2019/03/01 16:19:59.681] ----------------------------------------------------------------------
 [2019/03/01 16:19:59.681] Traceback (most recent call last):
 [2019/03/01 16:19:59.681]   File "/data/mci/92728139bf6b9643f3bf981438af4a9f/pymongo-mockup-tests/tests/test_reset_and_request_check.py", line 117, in test
 [2019/03/01 16:19:59.681]     test_method(self, operation)
 [2019/03/01 16:19:59.681]   File "/data/mci/92728139bf6b9643f3bf981438af4a9f/pymongo-mockup-tests/tests/test_reset_and_request_check.py", line 94, in _test_timeout
 [2019/03/01 16:19:59.681]     self.assertEqual(after, before, 'unneeded ismaster call')
 [2019/03/01 16:19:59.681] AssertionError: unneeded ismaster call
 [2019/03/01 16:19:59.681] ======================================================================
 [2019/03/01 16:19:59.681] FAIL: test_timeout_listIndexes (tests.test_reset_and_request_check.TestResetAndRequestCheck)
 [2019/03/01 16:19:59.681] ----------------------------------------------------------------------
 [2019/03/01 16:19:59.681] Traceback (most recent call last):
 [2019/03/01 16:19:59.681]   File "/data/mci/92728139bf6b9643f3bf981438af4a9f/pymongo-mockup-tests/tests/test_reset_and_request_check.py", line 117, in test
 [2019/03/01 16:19:59.681]     test_method(self, operation)
 [2019/03/01 16:19:59.681]   File "/data/mci/92728139bf6b9643f3bf981438af4a9f/pymongo-mockup-tests/tests/test_reset_and_request_check.py", line 94, in _test_timeout
 [2019/03/01 16:19:59.681]     self.assertEqual(after, before, 'unneeded ismaster call')
 [2019/03/01 16:19:59.681] AssertionError: unneeded ismaster call
 [2019/03/01 16:19:59.681] ======================================================================
 [2019/03/01 16:19:59.681] FAIL: test_timeout_options (tests.test_reset_and_request_check.TestResetAndRequestCheck)
 [2019/03/01 16:19:59.681] ----------------------------------------------------------------------
 [2019/03/01 16:19:59.681] Traceback (most recent call last):
 [2019/03/01 16:19:59.681]   File "/data/mci/92728139bf6b9643f3bf981438af4a9f/pymongo-mockup-tests/tests/test_reset_and_request_check.py", line 117, in test
 [2019/03/01 16:19:59.681]     test_method(self, operation)
 [2019/03/01 16:19:59.681]   File "/data/mci/92728139bf6b9643f3bf981438af4a9f/pymongo-mockup-tests/tests/test_reset_and_request_check.py", line 94, in _test_timeout
 [2019/03/01 16:19:59.681]     self.assertEqual(after, before, 'unneeded ismaster call')
 [2019/03/01 16:19:59.681] AssertionError: unneeded ismaster call
```

TODO: should we also add tests for retryReads=true? I'll have to look more into these tests to find out.