### PR TITLE
PYTHON-2799 Use namespace returned from initial command response for killCursors

### DIFF
--- a/tests/test_cursor_namespace.py
+++ b/tests/test_cursor_namespace.py
@@ -96,10 +96,12 @@ class TestKillCursorsNamespace(unittest.TestCase):
                 'killCursors': 'different.coll',
                 'cursors': [123],
                 '$db': 'different_db'})
-
-            request.reply({'cursor': {
-                'nextBatch': [{'doc': 2}],
-                'id': 0}})
+            request.reply({
+                'ok': 1,
+                'cursorsKilled': [123],
+                'cursorsNotFound': [],
+                'cursorsAlive': [],
+                'cursorsUnknown': []})
 
     def test_aggregate_killCursor(self):
         def op():

--- a/tests/test_cursor_namespace.py
+++ b/tests/test_cursor_namespace.py
@@ -69,5 +69,52 @@ class TestCursorNamespace(unittest.TestCase):
         self._test_cursor_namespace(op, 'listIndexes')
 
 
+class TestKillCursorsNamespace(unittest.TestCase):
+    @classmethod
+    @unittest.skipUnless(version_tuple >= (3, 12, -1), 'Fixed in pymongo 3.12')
+    def setUpClass(cls):
+        cls.server = MockupDB(auto_ismaster={'maxWireVersion': 6})
+        cls.server.run()
+        cls.client = MongoClient(cls.server.uri)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.client.close()
+        cls.server.stop()
+
+    def _test_killCursors_namespace(self, cursor_op, command):
+        with going(cursor_op):
+            request = self.server.receives(
+                **{command: 'collection', 'namespace': 'test'})
+            # Respond with a different namespace.
+            request.reply({'cursor': {
+                'firstBatch': [{'doc': 1}],
+                'id': 123,
+                'ns': 'different_db.different.coll'}})
+            # Client uses the namespace we returned for killCursors.
+            request = self.server.receives(**{
+                'killCursors': 'different.coll',
+                'cursors': [123],
+                '$db': 'different_db'})
+
+            request.reply({'cursor': {
+                'nextBatch': [{'doc': 2}],
+                'id': 0}})
+
+    def test_aggregate_killCursor(self):
+        def op():
+            cursor = self.client.test.collection.aggregate([], batchSize=1)
+            next(cursor)
+            cursor.close()
+        self._test_killCursors_namespace(op, 'aggregate')
+
+    def test_find_killCursor(self):
+        def op():
+            cursor = self.client.test.collection.find(batch_size=1)
+            next(cursor)
+            cursor.close()
+        self._test_killCursors_namespace(op, 'find')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Tested locally against changes introduced in https://github.com/mongodb/mongo-python-driver/pull/666

Testing without those changes produces the following errors:
```
======================================================================
FAIL: test_aggregate_killCursor (tests.test_cursor_namespace.TestKillCursorsNamespace)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/pmital/Developer/pymongo-mockup-tests/.eggs/mockupdb-1.8.0-py3.7.egg/mockupdb/__init__.py", line 178, in going
    yield future
  File "/Users/pmital/Developer/pymongo-mockup-tests/tests/test_cursor_namespace.py", line 98, in _test_killCursors_namespace
    '$db': 'different_db'})
  File "/Users/pmital/Developer/pymongo-mockup-tests/.eggs/mockupdb-1.8.0-py3.7.egg/mockupdb/__init__.py", line 1364, in receives
    % (matcher.prototype, request))
AssertionError: expected to receive Request({"killCursors": "different.coll", "cursors": [123], "$db": "different_db"}), got OpMsg({"killCursors": "collection", "cursors": [123], "$db": "test", "$readPreference": {"mode": "primary"}}, namespace="test")

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/pmital/Developer/pymongo-mockup-tests/tests/test_cursor_namespace.py", line 109, in test_aggregate_killCursor
    self._test_killCursors_namespace(op, 'aggregate')
  File "/Users/pmital/Developer/pymongo-mockup-tests/tests/test_cursor_namespace.py", line 102, in _test_killCursors_namespace
    'id': 0}})
  File "/Users/pmital/.pyenv/versions/3.7.10/lib/python3.7/contextlib.py", line 130, in __exit__
    self.gen.throw(type, value, traceback)
  File "/Users/pmital/Developer/pymongo-mockup-tests/.eggs/mockupdb-1.8.0-py3.7.egg/mockupdb/__init__.py", line 191, in going
    reraise(*exc_info)
  File "/Users/pmital/Developer/pymongo-mockup-tests/.eggs/mockupdb-1.8.0-py3.7.egg/mockupdb/__init__.py", line 78, in reraise
    raise exctype(str(value)).with_traceback(trace)
  File "/Users/pmital/Developer/pymongo-mockup-tests/.eggs/mockupdb-1.8.0-py3.7.egg/mockupdb/__init__.py", line 178, in going
    yield future
  File "/Users/pmital/Developer/pymongo-mockup-tests/tests/test_cursor_namespace.py", line 98, in _test_killCursors_namespace
    '$db': 'different_db'})
  File "/Users/pmital/Developer/pymongo-mockup-tests/.eggs/mockupdb-1.8.0-py3.7.egg/mockupdb/__init__.py", line 1364, in receives
    % (matcher.prototype, request))
AssertionError: expected to receive Request({"killCursors": "different.coll", "cursors": [123], "$db": "different_db"}), got OpMsg({"killCursors": "collection", "cursors": [123], "$db": "test", "$readPreference": {"mode": "primary"}}, namespace="test")

======================================================================
FAIL: test_find_killCursor (tests.test_cursor_namespace.TestKillCursorsNamespace)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/pmital/Developer/pymongo-mockup-tests/.eggs/mockupdb-1.8.0-py3.7.egg/mockupdb/__init__.py", line 178, in going
    yield future
  File "/Users/pmital/Developer/pymongo-mockup-tests/tests/test_cursor_namespace.py", line 98, in _test_killCursors_namespace
    '$db': 'different_db'})
  File "/Users/pmital/Developer/pymongo-mockup-tests/.eggs/mockupdb-1.8.0-py3.7.egg/mockupdb/__init__.py", line 1364, in receives
    % (matcher.prototype, request))
AssertionError: expected to receive Request({"killCursors": "different.coll", "cursors": [123], "$db": "different_db"}), got OpMsg({"killCursors": "collection", "cursors": [123], "$db": "test", "$readPreference": {"mode": "primary"}}, namespace="test")

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/pmital/Developer/pymongo-mockup-tests/tests/test_cursor_namespace.py", line 116, in test_find_killCursor
    self._test_killCursors_namespace(op, 'find')
  File "/Users/pmital/Developer/pymongo-mockup-tests/tests/test_cursor_namespace.py", line 102, in _test_killCursors_namespace
    'id': 0}})
  File "/Users/pmital/.pyenv/versions/3.7.10/lib/python3.7/contextlib.py", line 130, in __exit__
    self.gen.throw(type, value, traceback)
  File "/Users/pmital/Developer/pymongo-mockup-tests/.eggs/mockupdb-1.8.0-py3.7.egg/mockupdb/__init__.py", line 191, in going
    reraise(*exc_info)
  File "/Users/pmital/Developer/pymongo-mockup-tests/.eggs/mockupdb-1.8.0-py3.7.egg/mockupdb/__init__.py", line 78, in reraise
    raise exctype(str(value)).with_traceback(trace)
  File "/Users/pmital/Developer/pymongo-mockup-tests/.eggs/mockupdb-1.8.0-py3.7.egg/mockupdb/__init__.py", line 178, in going
    yield future
  File "/Users/pmital/Developer/pymongo-mockup-tests/tests/test_cursor_namespace.py", line 98, in _test_killCursors_namespace
    '$db': 'different_db'})
  File "/Users/pmital/Developer/pymongo-mockup-tests/.eggs/mockupdb-1.8.0-py3.7.egg/mockupdb/__init__.py", line 1364, in receives
    % (matcher.prototype, request))
AssertionError: expected to receive Request({"killCursors": "different.coll", "cursors": [123], "$db": "different_db"}), got OpMsg({"killCursors": "collection", "cursors": [123], "$db": "test", "$readPreference": {"mode": "primary"}}, namespace="test")
```