### PR TITLE
PYTHON-2720 Test PyMongo use OP_MSG for raw batches and exhaust cursors

### DIFF
--- a/tests/test_op_msg.py
+++ b/tests/test_op_msg.py
@@ -27,6 +27,16 @@ Operation = namedtuple(
 
 operations = [
     Operation(
+        'find_one',
+        lambda coll: coll.find_one({}),
+        request=OpMsg({"find": "coll"}, flags=0),
+        reply={'ok': 1, 'cursor': {'firstBatch': [], 'id': 0}}),
+    Operation(
+        'aggregate',
+        lambda coll: coll.aggregate([]),
+        request=OpMsg({"aggregate": "coll"}, flags=0),
+        reply={'ok': 1, 'cursor': {'firstBatch': [], 'id': 0}}),
+    Operation(
         'insert_one',
         lambda coll: coll.insert_one({}),
         request=OpMsg({"insert": "coll"}, flags=0),

--- a/tests/test_op_msg.py
+++ b/tests/test_op_msg.py
@@ -21,174 +21,174 @@ from pymongo.operations import InsertOne, UpdateOne, DeleteOne
 from tests import unittest
 
 
-WriteOperation = namedtuple(
-    'WriteOperation',
+Operation = namedtuple(
+    'Operation',
     ['name', 'function', 'request', 'reply'])
 
-write_operations = [
-    WriteOperation(
+operations = [
+    Operation(
         'insert_one',
         lambda coll: coll.insert_one({}),
         request=OpMsg({"insert": "coll"}, flags=0),
         reply={'ok': 1, 'n': 1}),
-    WriteOperation(
+    Operation(
         'insert_one-w0',
         lambda coll: coll.with_options(
             write_concern=WriteConcern(w=0)).insert_one({}),
         request=OpMsg({"insert": "coll"}, flags=OP_MSG_FLAGS['moreToCome']),
         reply=None),
-    WriteOperation(
+    Operation(
         'insert_many',
         lambda coll: coll.insert_many([{}, {}, {}]),
         request=OpMsg({"insert": "coll"}, flags=0),
         reply={'ok': 1, 'n': 3}),
-    WriteOperation(
+    Operation(
         'insert_many-w0',
         lambda coll: coll.with_options(
             write_concern=WriteConcern(w=0)).insert_many([{}, {}, {}]),
         request=OpMsg({"insert": "coll"}, flags=0),
         reply={'ok': 1, 'n': 3}),
-    WriteOperation(
+    Operation(
         'insert_many-w0-unordered',
         lambda coll: coll.with_options(
             write_concern=WriteConcern(w=0)).insert_many(
                 [{}, {}, {}], ordered=False),
         request=OpMsg({"insert": "coll"}, flags=OP_MSG_FLAGS['moreToCome']),
         reply=None),
-    WriteOperation(
+    Operation(
         'replace_one',
         lambda coll: coll.replace_one({"_id": 1}, {"new": 1}),
         request=OpMsg({"update": "coll"}, flags=0),
         reply={'ok': 1, 'n': 1, 'nModified': 1}),
-    WriteOperation(
+    Operation(
         'replace_one-w0',
         lambda coll: coll.with_options(
             write_concern=WriteConcern(w=0)).replace_one({"_id": 1},
                                                          {"new": 1}),
         request=OpMsg({"update": "coll"}, flags=OP_MSG_FLAGS['moreToCome']),
         reply=None),
-    WriteOperation(
+    Operation(
         'update_one',
         lambda coll: coll.update_one({"_id": 1}, {"$set": {"new": 1}}),
         request=OpMsg({"update": "coll"}, flags=0),
         reply={'ok': 1, 'n': 1, 'nModified': 1}),
-    WriteOperation(
+    Operation(
         'replace_one-w0',
         lambda coll: coll.with_options(
             write_concern=WriteConcern(w=0)).update_one({"_id": 1},
                                                         {"$set": {"new": 1}}),
         request=OpMsg({"update": "coll"}, flags=OP_MSG_FLAGS['moreToCome']),
         reply=None),
-    WriteOperation(
+    Operation(
         'update_many',
         lambda coll: coll.update_many({"_id": 1}, {"$set": {"new": 1}}),
         request=OpMsg({"update": "coll"}, flags=0),
         reply={'ok': 1, 'n': 1, 'nModified': 1}),
-    WriteOperation(
+    Operation(
         'update_many-w0',
         lambda coll: coll.with_options(
             write_concern=WriteConcern(w=0)).update_many({"_id": 1},
                                                          {"$set": {"new": 1}}),
         request=OpMsg({"update": "coll"}, flags=OP_MSG_FLAGS['moreToCome']),
         reply=None),
-    WriteOperation(
+    Operation(
         'delete_one',
         lambda coll: coll.delete_one({"a": 1}),
         request=OpMsg({"delete": "coll"}, flags=0),
         reply={'ok': 1, 'n': 1}),
-    WriteOperation(
+    Operation(
         'delete_one-w0',
         lambda coll: coll.with_options(
             write_concern=WriteConcern(w=0)).delete_one({"a": 1}),
         request=OpMsg({"delete": "coll"}, flags=OP_MSG_FLAGS['moreToCome']),
         reply=None),
-    WriteOperation(
+    Operation(
         'delete_many',
         lambda coll: coll.delete_many({"a": 1}),
         request=OpMsg({"delete": "coll"}, flags=0),
         reply={'ok': 1, 'n': 1}),
-    WriteOperation(
+    Operation(
         'delete_many-w0',
         lambda coll: coll.with_options(
             write_concern=WriteConcern(w=0)).delete_many({"a": 1}),
         request=OpMsg({"delete": "coll"}, flags=OP_MSG_FLAGS['moreToCome']),
         reply=None),
     # Legacy methods
-    WriteOperation(
+    Operation(
         'insert',
         lambda coll: coll.insert({}),
         request=OpMsg({"insert": "coll"}, flags=0),
         reply={'ok': 1, 'n': 1}),
-    WriteOperation(
+    Operation(
         'insert-w0',
         lambda coll: coll.with_options(
             write_concern=WriteConcern(w=0)).insert({}),
         request=OpMsg({"insert": "coll"}, flags=OP_MSG_FLAGS['moreToCome']),
         reply=None),
-    WriteOperation(
+    Operation(
         'insert-w0-argument',
         lambda coll: coll.insert({}, w=0),
         request=OpMsg({"insert": "coll"}, flags=OP_MSG_FLAGS['moreToCome']),
         reply=None),
-    WriteOperation(
+    Operation(
         'update',
         lambda coll: coll.update({"_id": 1}, {"new": 1}),
         request=OpMsg({"update": "coll"}, flags=0),
         reply={'ok': 1, 'n': 1, 'nModified': 1}),
-    WriteOperation(
+    Operation(
         'update-w0',
         lambda coll: coll.with_options(
             write_concern=WriteConcern(w=0)).update({"_id": 1}, {"new": 1}),
         request=OpMsg({"update": "coll"}, flags=OP_MSG_FLAGS['moreToCome']),
         reply=None),
-    WriteOperation(
+    Operation(
         'update-w0-argument',
         lambda coll: coll.update({"_id": 1}, {"new": 1}, w=0),
         request=OpMsg({"update": "coll"}, flags=OP_MSG_FLAGS['moreToCome']),
         reply=None),
-    WriteOperation(
+    Operation(
         'remove',
         lambda coll: coll.remove({"_id": 1}),
         request=OpMsg({"delete": "coll"}, flags=0),
         reply={'ok': 1, 'n': 1}),
-    WriteOperation(
+    Operation(
         'remove-w0',
         lambda coll: coll.with_options(
             write_concern=WriteConcern(w=0)).remove({"_id": 1}),
         request=OpMsg({"delete": "coll"}, flags=OP_MSG_FLAGS['moreToCome']),
         reply=None),
-    WriteOperation(
+    Operation(
         'remove-w0-argument',
         lambda coll: coll.remove({"_id": 1}, w=0),
         request=OpMsg({"delete": "coll"}, flags=OP_MSG_FLAGS['moreToCome']),
         reply=None),
-    WriteOperation(
+    Operation(
         'bulk_write_insert',
         lambda coll: coll.bulk_write([InsertOne({}), InsertOne({})]),
         request=OpMsg({"insert": "coll"}, flags=0),
         reply={'ok': 1, 'n': 2}),
-    WriteOperation(
+    Operation(
         'bulk_write_insert-w0',
         lambda coll: coll.with_options(
             write_concern=WriteConcern(w=0)).bulk_write([InsertOne({}),
                                                          InsertOne({})]),
         request=OpMsg({"insert": "coll"}, flags=0),
         reply={'ok': 1, 'n': 2}),
-    WriteOperation(
+    Operation(
         'bulk_write_insert-w0-unordered',
         lambda coll: coll.with_options(
             write_concern=WriteConcern(w=0)).bulk_write(
             [InsertOne({}), InsertOne({})], ordered=False),
         request=OpMsg({"insert": "coll"}, flags=OP_MSG_FLAGS['moreToCome']),
         reply=None),
-    WriteOperation(
+    Operation(
         'bulk_write_update',
         lambda coll: coll.bulk_write([
             UpdateOne({"_id": 1}, {"$set": {"new": 1}}),
             UpdateOne({"_id": 2}, {"$set": {"new": 1}})]),
         request=OpMsg({"update": "coll"}, flags=0),
         reply={'ok': 1, 'n': 2, 'nModified': 2}),
-    WriteOperation(
+    Operation(
         'bulk_write_update-w0',
         lambda coll: coll.with_options(
             write_concern=WriteConcern(w=0)).bulk_write([
@@ -196,7 +196,7 @@ write_operations = [
                 UpdateOne({"_id": 2}, {"$set": {"new": 1}})]),
         request=OpMsg({"update": "coll"}, flags=0),
         reply={'ok': 1, 'n': 2, 'nModified': 2}),
-    WriteOperation(
+    Operation(
         'bulk_write_update-w0-unordered',
         lambda coll: coll.with_options(
             write_concern=WriteConcern(w=0)).bulk_write([
@@ -204,20 +204,20 @@ write_operations = [
                 UpdateOne({"_id": 2}, {"$set": {"new": 1}})], ordered=False),
         request=OpMsg({"update": "coll"}, flags=OP_MSG_FLAGS['moreToCome']),
         reply=None),
-    WriteOperation(
+    Operation(
         'bulk_write_delete',
         lambda coll: coll.bulk_write([
             DeleteOne({"_id": 1}), DeleteOne({"_id": 2})]),
         request=OpMsg({"delete": "coll"}, flags=0),
         reply={'ok': 1, 'n': 2}),
-    WriteOperation(
+    Operation(
         'bulk_write_delete-w0',
         lambda coll: coll.with_options(
             write_concern=WriteConcern(w=0)).bulk_write([
                 DeleteOne({"_id": 1}), DeleteOne({"_id": 2})]),
         request=OpMsg({"delete": "coll"}, flags=0),
         reply={'ok': 1, 'n': 2}),
-    WriteOperation(
+    Operation(
         'bulk_write_delete-w0-unordered',
         lambda coll: coll.with_options(
             write_concern=WriteConcern(w=0)).bulk_write([
@@ -241,7 +241,7 @@ class TestOpMsg(unittest.TestCase):
         cls.server.stop()
         cls.client.close()
 
-    def _test_write_operation(self, op):
+    def _test_operation(self, op):
         coll = self.client.db.coll
         with going(op.function, coll) as future:
             request = self.server.receives()
@@ -252,17 +252,17 @@ class TestOpMsg(unittest.TestCase):
         future()  # No error.
 
 
-def write_operation_test(op):
+def operation_test(op):
     def test(self):
-        self._test_write_operation(op)
+        self._test_operation(op)
     return test
 
 
 def create_tests():
-    for op in write_operations:
+    for op in operations:
         test_name = "test_op_msg_%s" % (op.name,)
 
-        setattr(TestOpMsg, test_name, write_operation_test(op))
+        setattr(TestOpMsg, test_name, operation_test(op))
 
 
 create_tests()


### PR DESCRIPTION
This change depends on: https://github.com/ajdavis/mongo-mockup-db/pull/40